### PR TITLE
Add basic actions for PyPi builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# nmstore
-Neural Magic GHA
+# Neural Magic Actions
+Actions for Neural Magic GHA

--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -1,0 +1,56 @@
+name: "Build PyPi"
+description: "Build PyPi wheel"
+
+inputs:
+    dev:
+      description: 'If the build is a dev build'
+      required: false
+      default: false
+    release:
+      description: 'If the build is a release build'
+      required: false
+      default: false
+    name:
+      description: 'Name to append to the wheel'
+      required: false
+     
+outputs:
+    filename:
+      description: 'wheel filename'
+      value: ${{ steps.build.outputs.filename }}
+
+# can we just pass in build args instead of updating the variables in version.py?
+runs:
+  using: "composite"
+  steps:
+    - name: build 
+      shell: bash
+      run:  |
+            pwd
+            sudo apt-get -y install python3-pip
+            pip3 --version
+            sudo pip3 install virtualenv
+            virtualenv venv
+            source venv/bin/activate
+            pip install -e .
+            name="${{ inputs.name }}"
+            if ${{ inputs.release }}; then
+              sed -i 's/is_release = False/is_release = True/g' src/${{ github.event.repository.name }}/version.py
+            elif ${{ inputs.dev }}; then
+              sed -i 's/is_dev = False/is_dev = True/g' src/${{ github.event.repository.name }}/version.py
+              sed -i 's/dev_number = None/dev_number = '"$name"'/g' src/${{ github.event.repository.name }}/version.py
+            fi
+            status=$(make -B build || echo 'FAILED')
+            deactivate
+            echo "=========== Build log ==========="
+            echo "filename=dist/*.whl" >> "$GITHUB_OUTPUT"
+            echo "=========== Build status ==========="
+            if [[ "${status}" = "FAILED" ]]; then
+                echo "${{ github.event.repository.name }} build failed"
+                exitCode=1
+            else
+                echo "${{ github.event.repository.name }} build success"
+                exitCode=0
+            fi
+            echo "=========== Generated build ==========="
+            ls dist/

--- a/actions/s3_pull/action.yaml
+++ b/actions/s3_pull/action.yaml
@@ -1,0 +1,19 @@
+name: "Pull PyPi Wheel"
+description: "Pull PyPi wheel"
+
+inputs:
+  filename:
+    description: 'File to pull from s3 bucket'
+    required: true
+  dst:
+    description: 'Folder to pull down wheel file'
+    required: false
+    default: true 
+runs:
+  using: "composite"
+  steps:
+    - name: Push to s3
+      shell: bash
+      run:  |
+            aws s3 cp ${{ inputs.filename }} ${{ inputs.dst }}
+            exitCode=$?

--- a/actions/s3_push/action.yaml
+++ b/actions/s3_push/action.yaml
@@ -1,0 +1,31 @@
+name: "Push PyPi Wheel"
+description: "Push PyPi wheel"
+
+inputs:
+  filename:
+    description: 'File to push to s3'
+    required: true
+  internal:
+    description: 'Push to internal pypi or not'
+    required: false
+    default: true 
+outputs:
+  wheel:
+    description: 'Full path of the wheel'
+    value: ${{ steps.push-s3.outputs.wheel }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Push to s3
+      id: push-s3
+      shell: bash
+      run:  |
+            if ${{ inputs.internal }}; then
+              dst=s3://nm-actions-test/internal/${{ github.event.repository.name }}/
+            else
+              dst=s3://nm-actions-test/${{ github.event.repository.name }}/
+            fi
+            echo "wheel=$dst$(basename ${{ inputs.filename }})" >> $GITHUB_OUTPUT
+            aws s3 cp ${{ inputs.filename }} $dst
+            exitCode=$?


### PR DESCRIPTION
# Summary
- Adds 3 basic actions required by all Neural Magic build workflows
- These actions include: 

1.  `pypi_build` - will create a pypi wheel and name it correctly, depending on if the workflow is for a dev build, release build or nightly build
2. `s3_push` - push the wheel to s3 and correctly store it an s3 bucket depending on if wheel is being served on the internal pypi server or in production
3. `s3_pull` - basic action to pull down the wheel given the name and destination folder


- The 3 actions make the building blocks required to build all our pypi wheels for all 3 workflows (release, dev, nightly) and pull them for any additional testing
- The actions can be referenced in workflows, such as through the following example: 

```yaml
  name: Build PyPi Wheel
  id: build_wheel
  uses: neuralmagic/nm-actions/actions/pypi_build
  with:
    dev: $DEV
    release: $RELEASE
    name: $NAME
```
