### PR TITLE
Update push action to take in name of s3 bucket; update pypi build to remove virtualenv creation

### DIFF
--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -47,4 +47,4 @@ runs:
                 exitCode=0
             fi
             echo "=========== Generated build ==========="
-            ls
+            ls dist/

--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -35,7 +35,6 @@ runs:
               sed -i 's/dev_number = None/dev_number = '"$name"'/g' src/${{ github.event.repository.name }}/version.py
             fi
             status=$(make -B build || echo 'FAILED')
-            deactivate
             echo "=========== Build log ==========="
             echo "filename=dist/*.whl" >> "$GITHUB_OUTPUT"
             echo "=========== Build status ==========="

--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -26,13 +26,7 @@ runs:
     - name: build 
       shell: bash
       run:  |
-            pwd
-            sudo apt-get -y install python3-pip
-            pip3 --version
-            sudo pip3 install virtualenv
-            virtualenv venv
-            source venv/bin/activate
-            pip install -e .
+            pip3 install -e .
             name="${{ inputs.name }}"
             if ${{ inputs.release }}; then
               sed -i 's/is_release = False/is_release = True/g' src/${{ github.event.repository.name }}/version.py

--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -26,6 +26,7 @@ runs:
     - name: build 
       shell: bash
       run:  |
+            pip3 install wheel
             pip3 install -e .
             name="${{ inputs.name }}"
             if ${{ inputs.release }}; then
@@ -46,4 +47,4 @@ runs:
                 exitCode=0
             fi
             echo "=========== Generated build ==========="
-            ls dist/
+            ls

--- a/actions/s3_push/action.yaml
+++ b/actions/s3_push/action.yaml
@@ -9,6 +9,9 @@ inputs:
     description: 'Push to internal pypi or not'
     required: false
     default: true 
+  bucket_name:
+    type: string
+    required: true
 outputs:
   wheel:
     description: 'Full path of the wheel'
@@ -20,13 +23,11 @@ runs:
     - name: Push to s3
       id: push-s3
       shell: bash
-      env:
-        BUCKET: ${{ secrets.BUCKET_NAME }}
       run:  |
             if ${{ inputs.internal }}; then
-              dst=s3://$BUCKET/internal/${{ github.event.repository.name }}/
+              dst=s3://${{ inputs.bucket_name }}/internal/${{ github.event.repository.name }}/
             else
-              dst=s3://$BUCKET/${{ github.event.repository.name }}/
+              dst=s3://${{ inputs.bucket_name }}/${{ github.event.repository.name }}/
             fi
             echo "wheel=$dst$(basename ${{ inputs.filename }})" >> $GITHUB_OUTPUT
             aws s3 cp ${{ inputs.filename }} $dst

--- a/actions/s3_push/action.yaml
+++ b/actions/s3_push/action.yaml
@@ -20,11 +20,13 @@ runs:
     - name: Push to s3
       id: push-s3
       shell: bash
+      env:
+        BUCKET: ${{ secrets.BUCKET_NAME }}
       run:  |
             if ${{ inputs.internal }}; then
-              dst=s3://${{ secrets.BUCKET_NAME }}/internal/${{ github.event.repository.name }}/
+              dst=s3://$BUCKET/internal/${{ github.event.repository.name }}/
             else
-              dst=s3://${{ secrets.BUCKET_NAME }}/${{ github.event.repository.name }}/
+              dst=s3://$BUCKET/${{ github.event.repository.name }}/
             fi
             echo "wheel=$dst$(basename ${{ inputs.filename }})" >> $GITHUB_OUTPUT
             aws s3 cp ${{ inputs.filename }} $dst

--- a/actions/s3_push/action.yaml
+++ b/actions/s3_push/action.yaml
@@ -22,9 +22,9 @@ runs:
       shell: bash
       run:  |
             if ${{ inputs.internal }}; then
-              dst=s3://nm-actions-test/internal/${{ github.event.repository.name }}/
+              dst=s3://${{ secrets.BUCKET_NAME }}/internal/${{ github.event.repository.name }}/
             else
-              dst=s3://nm-actions-test/${{ github.event.repository.name }}/
+              dst=s3://${{ secrets.BUCKET_NAME }}/${{ github.event.repository.name }}/
             fi
             echo "wheel=$dst$(basename ${{ inputs.filename }})" >> $GITHUB_OUTPUT
             aws s3 cp ${{ inputs.filename }} $dst


### PR DESCRIPTION
SUMMARY:
- Allow the s3 push action to take the name of the bucket as an input
- Remove virtualenv set-up; should be done in another actions/outside this action

TEST PLAN:
- Tested in workflows updated by this PR: https://github.com/neuralmagic/sparseml/pulls

