### PR TITLE
Add 'install-testmo' action

### DIFF
--- a/actions/install-testmo/README.md
+++ b/actions/install-testmo/README.md
@@ -1,0 +1,13 @@
+# install-testmo
+
+This custom action will install Testmo (and the latest Node.js as a prerequisite).
+
+## Example usage
+
+Below is an example usage of this action from an external repository:
+
+```yaml
+steps:
+  - name: "Install Testmo CLI tool"
+    uses: neuralmagic/nm-actions/actions/install-testmo@main
+```

--- a/actions/install-testmo/README.md
+++ b/actions/install-testmo/README.md
@@ -1,10 +1,10 @@
 # install-testmo
 
-This custom action will install Testmo (and the latest Node.js as a prerequisite).
+This action will install Testmo (and the latest Node.js as a prerequisite).
 
 ## Example usage
 
-Below is an example usage of this action from an external repository:
+An example usage of this action from an external repository:
 
 ```yaml
 steps:

--- a/actions/install-testmo/action.yml
+++ b/actions/install-testmo/action.yml
@@ -1,0 +1,12 @@
+name: Install Testmo CLI tool
+description: Install Testmo including requirements (Node.js)
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+    - shell: bash
+      run: |
+        npm install --global @testmo/testmo-cli


### PR DESCRIPTION
SUMMARY:
Add an `install-testmo` action which will install the latest Node.js LTS release and the Testmo CLI tool. A simple README is included.

TEST PLAN:
See this run: https://github.com/neuralmagic/nm-actions/actions/runs/9488811206/job/26148628734
* Note that the `Install Testmo CLI tool` step uses the new action the same way a separate repo would
* Note that the next step, `Run echo "Hello, world!"`, shows the versions of the newly installed tools

As that run may not stick around forever, here is a screenshot:
![Screenshot 2024-06-12 155231-fs8](https://github.com/neuralmagic/nm-actions/assets/642904/c852cc72-477e-416a-ba42-f25fae715ee0)
