### PR TITLE
Add 'set-python' action

### DIFF
--- a/actions/set-python/README.md
+++ b/actions/set-python/README.md
@@ -1,0 +1,31 @@
+# set-python
+
+This action sets the local version of Python and creates a virtual environment.
+
+## Requirements
+
+This action requires `pyenv` to be installed.
+
+## Usage
+
+`set-python` accepts two inputs (both required) and yields a single output:
+
+### Inputs
+
+* `python`: the python version to use
+* `venv`: the base name for the virtual environment
+
+### Output
+
+* `version`: the full Python version (from `python --version`)
+
+### Example
+
+```yaml
+steps:
+  - name: "Set Python"
+    uses: neuralmagic/nm-actions/actions/set-python@main
+      with:
+        python: 3.10.12
+        venv: BUILD
+```

--- a/actions/set-python/action.yml
+++ b/actions/set-python/action.yml
@@ -1,0 +1,31 @@
+name: Set Python
+description: Sets the Python version and creates a virtual environment
+
+inputs:
+  python:
+    description: Python version to use (e.g., 3.10.12)
+    required: true
+  venv:
+    description: Base name for virtual environment
+    required: true
+
+outputs:
+  version:
+    description: Full Python version (from `python --version`)
+    value: ${{ steps.set_python.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: set_python
+      shell: bash
+      run: |
+        pyenv local ${{ inputs.python }}
+
+        COMMIT=${{ github.sha }}
+        VENV="${{ inputs.venv }}-${COMMIT:0:7}"
+        pyenv virtualenv --force ${VENV}
+        source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
+
+        VERSION=$(python --version)
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/actions/set-python/action.yml
+++ b/actions/set-python/action.yml
@@ -13,6 +13,9 @@ outputs:
   version:
     description: Full Python version (from `python --version`)
     value: ${{ steps.set_python.outputs.version }}
+  venv_path:
+    description: Absolute path to the virtual environment folder
+    value: ${{ steps.set_python.outputs.venv_path }}
 
 runs:
   using: composite
@@ -24,8 +27,10 @@ runs:
 
         COMMIT=${{ github.sha }}
         VENV="${{ inputs.venv }}-${COMMIT:0:7}"
-        pyenv virtualenv --force ${VENV}
-        source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
+        pyenv virtualenv --force "$VENV"
+        VENV_PATH="$(pyenv root)/versions/${{ inputs.python }}/envs/$VENV
+        source "$VENV_PATH/bin/activate"
 
         VERSION=$(python --version)
-        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "venv_path=$VENV_PATH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
SUMMARY:
Add a `set-python` action which uses pyenv (required to use the action) to set the local Python version to the one specifed by the `python` input and create a virtual environment using the `venv` input as the base name. It yields two outputs:
* `version`: the full version of the Python executable that is active
* `venv_path`: the absolute path to the root venv folder
  * ex., use `source "${{ steps.STEP_ID_PLACEHOLDER.outputs.venv_path }}/bin/activate"` to easily activate the created virtual environment

TEST PLAN:
n/a

