### PR TITLE
Add 'install-automation-components' action

### DIFF
--- a/actions/install-automation-components/README.md
+++ b/actions/install-automation-components/README.md
@@ -1,0 +1,17 @@
+# install-automation-components
+
+This action will install various basic tools/components used during automation such as `curl`, `git`, and `wget`.
+
+## Requirements
+
+This action is currently designed to be used in a Debian-based environment — specifically, one using `apt` as the package manager.
+
+## Usage
+
+### Example
+
+```yaml
+steps:
+  - name: Install automation components
+    uses: neuralmagic/nm-actions/actions/install-automation-components@main
+```

--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -1,0 +1,10 @@
+name: Install Automation Components
+description: Install various components used during automation
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        sudo apt-get update --fix-missing
+        sudo apt-get install -y curl git-all wget


### PR DESCRIPTION
SUMMARY:
Add an `install-automation-components` action which installs various tools required during automation (e.g., `curl`, `git`, `wget`). Requires a Debian-based environment (specifically, one using `apt` for package management).

TEST PLAN:
"please outline how the changes were tested"

