### PR TITLE
fix bug for version.py path

### DIFF
--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -29,11 +29,12 @@ runs:
             pip3 install wheel
             pip3 install -e .
             name="${{ inputs.name }}"
+            ver_file=`find . type f -name 'version.py'`
             if ${{ inputs.release }}; then
-              sed -i 's/is_release = False/is_release = True/g' src/${{ github.event.repository.name }}/version.py
+              sed -i 's/is_release = False/is_release = True/g' ${ver_file}
             elif ${{ inputs.dev }}; then
-              sed -i 's/is_dev = False/is_dev = True/g' src/${{ github.event.repository.name }}/version.py
-              sed -i 's/dev_number = None/dev_number = '"$name"'/g' src/${{ github.event.repository.name }}/version.py
+              sed -i 's/is_dev = False/is_dev = True/g' ${ver_file}
+              sed -i 's/dev_number = None/dev_number = '"$name"'/g' ${ver_file}
             fi
             status=$(make -B build || echo 'FAILED')
             echo "=========== Build log ==========="

--- a/actions/pypi_build/action.yaml
+++ b/actions/pypi_build/action.yaml
@@ -1,5 +1,5 @@
 name: "Build PyPi"
-description: "Build PyPi wheel"
+description: "Build PyPi wheel for ML repos e.g. sparseml, compressed-tensors"
 
 inputs:
     dev:


### PR DESCRIPTION
SUMMARY:
Due to the folder name, version.py file is not always under src/[repo-name]/version.py and this caused build to fail. This fixes this issue and can handle any path that version.py may locate.

TEST PLAN:
All tests

