### PR TITLE
Fix `set-python` action

### DIFF
--- a/actions/set-python/README.md
+++ b/actions/set-python/README.md
@@ -15,9 +15,11 @@ This action requires `pyenv` to be installed.
 * `python`: the python version to use
 * `venv`: the base name for the virtual environment
 
-### Output
+### Outputs
 
 * `version`: the full Python version (from `python --version`)
+* `venv_path`: the full path to the virtual environment’s base folder
+  * ex. `source ${{ steps.set_python.outputs.venv_path }}/bin/activate`
 
 ### Example
 

--- a/actions/set-python/action.yml
+++ b/actions/set-python/action.yml
@@ -28,9 +28,10 @@ runs:
         COMMIT=${{ github.sha }}
         VENV="${{ inputs.venv }}-${COMMIT:0:7}"
         pyenv virtualenv --force "$VENV"
-        VENV_PATH="$(pyenv root)/versions/${{ inputs.python }}/envs/$VENV
-        source "$VENV_PATH/bin/activate"
 
+        VENV_PATH="$(pyenv root)/versions/${{ inputs.python }}/envs/$VENV"
+        source "$VENV_PATH/bin/activate"
         VERSION=$(python --version)
+
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "venv_path=$VENV_PATH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
SUMMARY:
* Fix a missing quote in the set-python action script
* Add documentation for its `venv_path` output

TEST PLAN:
n/a

