### PR TITLE
Fix typo in function name when called

### DIFF
--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -65,7 +65,7 @@ runs:
             --instance ${TESTMO_URL} \
             --run-id ${TESTMO_RUN_ID} \
             --results ${RESULTS} \
-            -- step-status "${{ inputs.step_status }}" || SUCCESS=$?
+            -- step_status "${{ inputs.step_status }}" || SUCCESS=$?
         fi
         echo "status=${SUCCESS}" >> "$GITHUB_OUTPUT"
         exit ${SUCCESS}


### PR DESCRIPTION
## Summary:

Fixes a bug in `actions/testmo-run-submit-thread/action.yml` where the `step_status` function defined was being called by the wrong name later.

## Test Plan:

Related logic tested independently with an action that runs the problem area using Bash script:

```bash
step_status() {
  # echo "green encased checkmark" if "${1} == 0"
  # echo "red X"                   if "${1} != 0"

  if [ "$1" -eq 0 ]; then
    # green check
    echo -e "\xE2\x9C\x85"
  else
    # red x
    echo -e "\xE2\x9D\x8C"
  fi
}

step_status 0
step_status 1
step_status -12
```

Output:

```
✅
❌
❌
```