### PR TITLE
Support destination path in gcp-download-assets

### DIFF
--- a/actions/gcp-download-assets/action.yml
+++ b/actions/gcp-download-assets/action.yml
@@ -12,7 +12,7 @@ inputs:
   dest_path:
     description: 'path where the assets should be downloaded (default: ".")'
     required: false
-    default: '.'
+    default: .
 
 runs:
   using: composite

--- a/actions/gcp-download-assets/action.yml
+++ b/actions/gcp-download-assets/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - id: download
       run: |
-        gcloud storage cp "$BUCKET_SOURCE/$RUN_ID/" "$PATH" --recursive
+        gcloud storage cp "$BUCKET_SOURCE/$RUN_ID/" "$DEST_PATH" --recursive
       shell: bash
       env:
         BUCKET_SOURCE: ${{ inputs.bucket_source }}

--- a/actions/gcp-download-assets/action.yml
+++ b/actions/gcp-download-assets/action.yml
@@ -19,6 +19,9 @@ runs:
   steps:
     - id: download
       run: |
+        if [[ "$DEST_PATH" != "." && ! -e "$DEST_PATH" ]]; then
+          mkdir -p "$DEST_PATH"
+        fi
         gcloud storage cp "$BUCKET_SOURCE/$RUN_ID/" "$DEST_PATH" --recursive
       shell: bash
       env:

--- a/actions/gcp-download-assets/action.yml
+++ b/actions/gcp-download-assets/action.yml
@@ -14,11 +14,6 @@ inputs:
     required: false
     default: '.'
 
-outputs:
-  asset:
-    description: REPO relative path to downloaded "whl"
-    value: ${{ steps.download.outputs.asset }}
-
 runs:
   using: composite
   steps:

--- a/actions/gcp-download-assets/action.yml
+++ b/actions/gcp-download-assets/action.yml
@@ -9,6 +9,10 @@ inputs:
   run_id:
     description: GHA run id of build
     required: true
+  dest_path:
+    description: 'path where the assets should be downloaded (default: ".")'
+    required: false
+    default: '.'
 
 outputs:
   asset:
@@ -20,5 +24,9 @@ runs:
   steps:
     - id: download
       run: |
-        gcloud storage cp ${{ inputs.bucket_source }}/${{ inputs.run_id }}/ . --recursive
+        gcloud storage cp "$BUCKET_SOURCE/$RUN_ID/" "$PATH" --recursive
       shell: bash
+      env:
+        BUCKET_SOURCE: ${{ inputs.bucket_source }}
+        RUN_ID: ${{ inputs.run_id }}
+        DEST_PATH: ${{ inputs.dest_path }}


### PR DESCRIPTION
## Summary:

Add an *optional* `dest_path` input to `gcp-download-assets` which controls the destination where the assets are downloaded. It defaults to `.` to maintain backward compatibility with existing jobs that don’t pass it in.

A bit of cleanup is also performed:
* The `outputs` block has been removed since it no longer actually outputs what was defined
* The shell script is updated to use environment variables so GitHub’s preprocessing interpolation does not interfere with debugging capabilities.
