### PR TITLE
Refactor `testmo-run-submit-thread`

### DIFF
--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -41,7 +41,7 @@ runs:
         if [[ ! -d "$RESULTS_FOLDER" ]]; then
           echo "Results folder '$RESULTS_FOLDER' does not exist in working directory:"
           ls -A
-          echo "::warning title=MISSING RESULTS FOLDER::Results folder does not exist in working directory"
+          echo "::warning title=$GITHUB_JOB - MISSING RESULTS FOLDER::Results folder does not exist in working directory"
           exit
         fi
 
@@ -50,7 +50,7 @@ runs:
         if [[ -z "$RESULTS" ]]; then
           echo "Results folder '$RESULTS_FOLDER' does not contain any XML result files:"
           ls -A "$RESULTS_FOLDER"
-          echo "::warning title=MISSING RESULT FILES::Results folder did not contain any XML result files"
+          echo "::warning title=$GITHUB_JOB - MISSING RESULT FILES::Results folder did not contain any XML result files"
           exit
         fi
 

--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -37,42 +37,48 @@ runs:
 
     - id: submit_thread
       run: |
-        # verify there are result files to be submitted
-        ls -Al
-        REPORT=1
-        RESULTS=
-        if [[ ! -d ${{ inputs.results }} ]]; then
-          REPORT=0
-        else
-          RESULTS=$(find ${{ inputs.results }} -type f -name "*.xml")
+        # verify results folder exists
+        if [[ ! -d "$RESULTS_FOLDER" ]]; then
+          echo "Results folder '$RESULTS_FOLDER' does not exist in working directory:"
+          ls -A
+          echo "::warning title=MISSING RESULTS FOLDER::Results folder does not exist in working directory"
+          exit
         fi
-        if [[ -z "${RESULTS}" ]]; then
-          REPORT=0
+
+        # verify results folder contains XML result files
+        RESULTS=$(find "$RESULTS_FOLDER" -type f -name "*.xml")
+        if [[ -z "$RESULTS" ]]; then
+          echo "Results folder '$RESULTS_FOLDER' does not contain any XML result files:"
+          ls -A "$RESULTS_FOLDER"
+          echo "::warning title=MISSING RESULT FILES::Results folder did not contain any XML result files"
+          exit
+        fi
+
+        # generate resources file if necessary
+        if [[ -f "$THREAD_RESOURCES" ]]; then
+          thread_resources=$THREAD_RESOURCES
+        else
+          echo '{}' > thread_resources.json
+          thread_resources=thread_resources.json
         fi
 
         # submit results
         SUCCESS=0
-        if [[ ${REPORT} -eq 1 ]]; then
-          echo "submitting results to TESTMO run ..."
-          ## not checking testmo_url and token as this should be
-          ## called between "create" and "complete"
-          if [[ -f "${{ inputs.thread_resources }}" ]]; then
-            thread_resources=${{ inputs.thread_resources }}
-          else
-            echo '{}' > thread_resources.json
-            thread_resources=thread_resources.json
-          fi
-          npx testmo automation:run:submit-thread \
-            --instance ${TESTMO_URL} \
-            --run-id ${TESTMO_RUN_ID} \
-            --results ${RESULTS} \
-            --thread-resources ${thread_resources} \
-            -- step-status.sh "${{ inputs.step_status }}" || SUCCESS=$?
-        fi
-        echo "status=${SUCCESS}" >> "$GITHUB_OUTPUT"
-        exit ${SUCCESS}
+        echo "submitting results to TESTMO run ..."
+        npx testmo automation:run:submit-thread \
+          --instance "$TESTMO_URL" \
+          --run-id "$TESTMO_RUN_ID" \
+          --results "$RESULTS" \
+          --thread-resources "$thread_resources" \
+          -- step-status.sh "$STEP_STATUS" || SUCCESS=$?
+
+        echo "status=$SUCCESS" >> "$GITHUB_OUTPUT"
+        exit "$SUCCESS"
       env:
         TESTMO_URL: ${{ inputs.testmo_url }}
         TESTMO_TOKEN: ${{ inputs.testmo_token }}
         TESTMO_RUN_ID: ${{ inputs.testmo_run_id }}
+        RESULTS_FOLDER: ${{ inputs.results }}
+        THREAD_RESOURCES: ${{ inputs.thread_resources }}
+        STEP_STATUS: ${{ inputs.step_status }}
       shell: bash

--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -42,7 +42,7 @@ runs:
           echo "Results folder '$RESULTS_FOLDER' does not exist in working directory:"
           ls -A
           echo "::warning title=$GITHUB_JOB - MISSING RESULTS FOLDER::Results folder does not exist in working directory"
-          exit
+          exit 1
         fi
 
         # verify results folder contains XML result files
@@ -51,7 +51,7 @@ runs:
           echo "Results folder '$RESULTS_FOLDER' does not contain any XML result files:"
           ls -A "$RESULTS_FOLDER"
           echo "::warning title=$GITHUB_JOB - MISSING RESULT FILES::Results folder did not contain any XML result files"
-          exit
+          exit 1
         fi
 
         # generate resources file if necessary


### PR DESCRIPTION
## Summary:

These changes refactor the `testmo-run-submit-thread` action to reduce complexity and improve output (without any functional changes):

* Total number of variables and amount of nesting has been greatly reduced to simplify reading through the code
* All inputs are mapped to environment variables and only used that way to help debugging
* Explicit error messages are displayed for different error scenarios (missing folder, missing files)
  * The action ends immediately if those scenarios are triggered
  * Relevant output (`ls` output) is confined to those scenarios
  * A summary-level warning is emitted to help bring visibility to this scenario
* Error paths that include these error messages will also fail the step/action

## Test Plan:

This run has a workflow running three jobs with the current changes: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/11166974501
* `TEST-HAPPY` — the happy path, calls the action with a results folder that contains results files. All is well!
* `TEST-MISSING-FOLDER` — calls the action with a results folder that doesn't exist. Everything still works as expected including Testmo integration, a warning is present at the summary level, and concise, detailed output is present in the step output.
* `TEST-EMPTY-FOLDER` — calls the action with a results folder that exists but does not contain any XML result files. Everything still works as expected including Testmo integration, a warning is present at the summary level, and concise, detailed output is present in the step output.