### PR TITLE
updates to install automation components 

### DIFF
--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -10,14 +10,15 @@ runs:
         # packages
         sudo apt-get update --fix-missing
         sudo apt-get install -y curl git-all wget jq
-        # gh cli
-        (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-        && sudo mkdir -p -m 755 /etc/apt/keyrings \
-        && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-        && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        && sudo apt update \
-        && sudo apt install gh -y
         # install gcc
         sudo apt update -y
-        sudo apt install -y gcc g++ lld
+        sudo apt install -y gcc-10 g++-10 lld
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+        # # gh cli
+        # (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+        # && sudo mkdir -p -m 755 /etc/apt/keyrings \
+        # && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+        # && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        # && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+        # && sudo apt update \
+        # && sudo apt install gh -y

--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -7,20 +7,14 @@ runs:
   steps:
     - shell: bash
       run: |-
-        # apt and apt-get updates
-        cd /var/lib/apt/lists/
-        sudo rm *
-        cd ~
-        sudo apt update -y
-        sudo apt-get update --fix-missing
         # packages
-        sudo apt-get install -y curl git-all wget jq
-        # install gcc
         sudo apt update -y
+        sudo apt install -y curl git-all wget jq
+        # install gcc
         sudo apt install -y gcc-10 g++-10 lld
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 --slave /usr/bin/g++ g++ /usr/bin/g++-10
         # gh cli
-        (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+        (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
         && sudo mkdir -p -m 755 /etc/apt/keyrings \
         && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
         && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -7,18 +7,23 @@ runs:
   steps:
     - shell: bash
       run: |-
-        # packages
+        # packages lists
+        cd /var/lib/apt/lists/
+        sudo rm *
+        cd ~
+        sudo apt update -y
         sudo apt-get update --fix-missing
+        # packages
         sudo apt-get install -y curl git-all wget jq
         # install gcc
         sudo apt update -y
         sudo apt install -y gcc-10 g++-10 lld
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-        # # gh cli
-        # (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-        # && sudo mkdir -p -m 755 /etc/apt/keyrings \
-        # && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-        # && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-        # && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        # && sudo apt update \
-        # && sudo apt install gh -y
+        # gh cli
+        (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+        && sudo mkdir -p -m 755 /etc/apt/keyrings \
+        && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+        && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+        && sudo apt update \
+        && sudo apt install gh -y

--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
     - shell: bash
       run: |-
-        # packages lists
+        # apt and apt-get updates
         cd /var/lib/apt/lists/
         sudo rm *
         cd ~


### PR DESCRIPTION
## Summary:
* Remove usage of `apt-get` in "install automation components". The older `ubuntu` versions on AWS in `us-east-1` have outdated "REPOs" which cause installs to fail. Using `apt` to do the installs addresses the issues.
* Also updated "gcc" to version 10.5.

## Test Plan:
Bringing up debug instances and verifying the installation.
