### PR TITLE
Refactor nm-actions/install-whl

### DIFF
--- a/actions/install-whl/action.yml
+++ b/actions/install-whl/action.yml
@@ -31,6 +31,7 @@ runs:
 
         echo "::group::pip install $whl"
         pip install "$whl"
+
         version=$(pip freeze | grep "$NAME")
         echo "installed $version"
         echo "::endgroup::"

--- a/actions/install-whl/action.yml
+++ b/actions/install-whl/action.yml
@@ -17,15 +17,21 @@ runs:
   using: composite
   steps:
     - id: install_whl
+      env:
+        VENV: ${{ inputs.venv }}
+        NAME: ${{ inputs.name }}
+        EXTRA: ${{ inputs.extra }}
       run: |
-        source ${{ inputs.venv }}/bin/activate
-        python --version
-        WHL=$(find . -type f -iname "${{ inputs.name }}*.whl")
-        if [ ! -z "${{ inputs.extra }}" ]; then
-          pip install ${WHL}${{ inputs.extra }}
-        else
-          pip install ${WHL}
+        source "$VENV/bin/activate"
+
+        whl=$(find . -type f -iname "$NAME*.whl")
+        if [ -n "$EXTRA" ]; then
+          whl="$whl$EXTRA"
         fi
-        version=$(pip freeze | grep "${{ inputs.name }}")
-        echo "installed ${version}"
+
+        echo "::group::pip install $whl"
+        pip install "$whl"
+        version=$(pip freeze | grep "$NAME")
+        echo "installed $version"
+        echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
This refactor reduces complexity (simpler conditional construct) and groups output for the `install-whl` action:

* Inputs are mapped to environment variables, which significantly increases the readability when viewing the action invocation during a run. When you expand the action source, you can see all the variable names – when using inputs directly, they are replaced prior to this, meaning an empty input will simply have emptiness in the source code with no referential data.
* Reduce the general complexity of the code in the action (e.g., eliminate branching conditionals).
* Add output grouping — since this step is often used as part of another action, including output grouping is a considerable readability improvement for those runs, so this action’s output doesn’t forcibly increase noise during the run.

An example of these changes can be found in this run, under the “run e2e tests” step (see screenshot highlighting how the output is now grouped in that run): https://github.com/neuralmagic/llm-compressor-testing/actions/runs/11846143475/job/33013305664

![image](https://github.com/user-attachments/assets/e4a07c6a-149f-4f16-a2bc-05935fabdf76)
