### PR TITLE
Make Testmo actions self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: ACTION
-      uses: neuralmagic/nm-actions/ACTION@main
+      uses: neuralmagic/nm-actions/actions/ACTION@main
       with:
         config-file: .eslintrc
 ```

--- a/actions/install-testmo/action.yml
+++ b/actions/install-testmo/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
       run: |-
         NEEDS_NODE=0
-        if ! command -v node; then
+        if ! command -v node &> /dev/null; then
           NEEDS_NODE=1
           echo "install-testmo - latest Node.js LTS will be installed via actions/setup-node"
         else

--- a/actions/install-testmo/action.yml
+++ b/actions/install-testmo/action.yml
@@ -1,13 +1,30 @@
 ---
 name: Install Testmo CLI tool
-description: Install Testmo including requirements (Node.js)
+description: Install Testmo including requirements (Node.js) if necessary
 
 runs:
   using: composite
   steps:
+    - id: check-node
+      shell: bash
+      run: |-
+        NEEDS_NODE=0
+        if ! command -v node; then
+          NEEDS_NODE=1
+        else
+          echo "install-testmo - Node.js $(node --version) already installed"
+        fi
+        echo "NEEDS_NODE=$NEEDS_NODE" >> "$GITHUB_OUTPUT"
+
     - uses: actions/setup-node@v4
+      if: ${{ steps.check-node.outputs.NEEDS_NODE == '1' }}
       with:
         node-version: lts/*
+
     - shell: bash
       run: |-
-        npm install --global @testmo/testmo-cli
+        if ! npx testmo --help &> /dev/null; then
+          npm install --global @testmo/testmo-cli
+        else
+          echo "install-testmo - testmo-cli $(npx testmo --version) already installed"
+        fi

--- a/actions/install-testmo/action.yml
+++ b/actions/install-testmo/action.yml
@@ -11,6 +11,7 @@ runs:
         NEEDS_NODE=0
         if ! command -v node; then
           NEEDS_NODE=1
+          echo "install-testmo - latest Node.js LTS will be installed via actions/setup-node"
         else
           echo "install-testmo - Node.js $(node --version) already installed"
         fi
@@ -25,6 +26,7 @@ runs:
       run: |-
         if ! npx testmo --help &> /dev/null; then
           npm install --global @testmo/testmo-cli
+          echo "install-testmo - installed testmo-cli $(npx testmo --version)"
         else
           echo "install-testmo - testmo-cli $(npx testmo --version) already installed"
         fi

--- a/actions/install-testmo/action.yml
+++ b/actions/install-testmo/action.yml
@@ -25,7 +25,7 @@ runs:
     - shell: bash
       run: |-
         if ! npx testmo --help &> /dev/null; then
-          npm install --global @testmo/testmo-cli
+          npm install --global --no-fund @testmo/testmo-cli
           echo "install-testmo - installed testmo-cli $(npx testmo --version)"
         else
           echo "install-testmo - testmo-cli $(npx testmo --version) already installed"

--- a/actions/testmo-create-resources/action.yml
+++ b/actions/testmo-create-resources/action.yml
@@ -15,6 +15,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: install Testmo CLI tool
+      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+
     - name: add actions path to PATH
       shell: bash
       run: echo "${{ github.action_path }}" >> $GITHUB_PATH

--- a/actions/testmo-run-complete/action.yml
+++ b/actions/testmo-run-complete/action.yml
@@ -16,6 +16,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: install Testmo CLI tool
+      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+
     - run: |
         echo "completing TESTMO run ..."
         ## CHECK testmo_url and token

--- a/actions/testmo-run-create/action.yml
+++ b/actions/testmo-run-create/action.yml
@@ -27,6 +27,9 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: install Testmo CLI tool
+      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+
     - name: create run
       id: testmo_id
       run: |

--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -31,6 +31,9 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: install Testmo CLI tool
+      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+
     - name: add scripts folder to PATH
       run: echo "${{ github.action_path }}/../../scripts" >> $GITHUB_PATH
       shell: bash


### PR DESCRIPTION
## Summary:

Make the Testmo actions self-contained so that consuming workflows don’t need to worry about installing any dependencies.

## Details:

Each of the Testmo usage actions now call the `install-testmo` action first, ensuring the action’s dependencies are installed. 

Also, the `install-testmo` action itself is updated with some checks so that Node.js and the Testmo CLI tool are only installed if not already available.

The one caveat is that they are all currently set to use the (next) version tag from this repo, `1.10.0`. So long as the tag is created shortly after this PR is merged, this is negligible (and wouldn’t affect any existing repos, as they would be using the older version tag for these actions).

## Test Plan:

This run (which expectedly failed with invalid inputs/credentials) shows this change working in the `testmo-run-create` action (it only uses that one action after checkout): https://github.com/neuralmagic/nm-actions/actions/runs/12301377628/job/34331825686

- If you review the output in the `Run neuralmagic/nm-actions/actions/testmo-run-create@self-contained-testmo-actions-test` step, you can see Node.js/Testmo CLI tool being checked for and installed
- Further down the output toward the end, the message "Project ID needs to be a positive number" is actually from the Testmo CLI tool itself, proving that it was installed successfully in order to be able to generate that message