### PR TITLE
Fix multi-file results in `testmo-run-submit-thread` action

### DIFF
--- a/actions/testmo-create-resources/action.yml
+++ b/actions/testmo-create-resources/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: install Testmo CLI tool
-      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+      uses: neuralmagic/nm-actions/actions/install-testmo@v1.11.0
 
     - name: add actions path to PATH
       shell: bash

--- a/actions/testmo-run-complete/action.yml
+++ b/actions/testmo-run-complete/action.yml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: install Testmo CLI tool
-      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+      uses: neuralmagic/nm-actions/actions/install-testmo@v1.11.0
 
     - run: |
         echo "completing TESTMO run ..."

--- a/actions/testmo-run-create/action.yml
+++ b/actions/testmo-run-create/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: install Testmo CLI tool
-      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+      uses: neuralmagic/nm-actions/actions/install-testmo@v1.11.0
 
     - name: create run
       id: testmo_id

--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -49,8 +49,8 @@ runs:
         fi
 
         # verify results folder contains XML result files
-        RESULTS=$(find "$RESULTS_FOLDER" -type f -name "*.xml")
-        if [[ -z "$RESULTS" ]]; then
+        readarray -d '' RESULTS < <(find "$RESULTS_FOLDER" -type f -name "*.xml" -print0)
+        if [[ ${#RESULTS[@]} == 0 ]]; then
           echo "Results folder '$RESULTS_FOLDER' does not contain any XML result files:"
           ls -A "$RESULTS_FOLDER"
           echo "::warning title=$GITHUB_JOB - MISSING RESULT FILES::Results folder did not contain any XML result files"
@@ -71,7 +71,7 @@ runs:
         npx testmo automation:run:submit-thread \
           --instance "$TESTMO_URL" \
           --run-id "$TESTMO_RUN_ID" \
-          --results "$RESULTS" \
+          --results "${RESULTS[@]}" \
           --thread-resources "$thread_resources" \
           -- step-status.sh "$STEP_STATUS" || SUCCESS=$?
 

--- a/actions/testmo-run-submit-thread/action.yml
+++ b/actions/testmo-run-submit-thread/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: install Testmo CLI tool
-      uses: neuralmagic/nm-actions/actions/install-testmo@1.10.0
+      uses: neuralmagic/nm-actions/actions/install-testmo@v1.11.0
 
     - name: add scripts folder to PATH
       run: echo "${{ github.action_path }}/../../scripts" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary:

This is a bugfix PR regarding the way the Testmo CLI was receiving the list of result files.

## Details:

The proposed fix uses an array to maintain argument safety around spaces/etc. in unexpected places (e.g. within a file or folder name) while passing multiple files as distinct values to the Testmo CLI tool.

## Test Plan:

This test run’s TEST steps use the new version: https://github.com/neuralmagic/nm-vllm-ent/actions/runs/12382354312