### PR TITLE
Install required build tools

### DIFF
--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -40,7 +40,7 @@ runs:
         if [[ ! -z "${{ inputs.venv }}" ]]; then
             source ${{ inputs.venv }}/bin/activate
         fi
-        pip install wheel
+        pip install setuptools wheel
         name="${{ inputs.name }}"
         ver_file=$(find . -type f -name "version.py")
         if ${{ inputs.release }}; then


### PR DESCRIPTION
With Python 3.12 and later, virtual environments only get `pip` installed by default (`setuptools` is no longer included). Since we require `setuptools` and use the older `setup.py` method, this PR includes the installation of `setuptools` prior to building in case it's not already installed.