### PR TITLE
Fix 'changed-files' action

### DIFF
--- a/actions/changed-files/README.md
+++ b/actions/changed-files/README.md
@@ -1,0 +1,50 @@
+# Summary
+
+Used to filter changed files in the current push/pull request.
+
+## Usage
+
+### Inputs
+
+* `include-patterns` (required): one or more newline-separated patterns to match changed files. To match any file, use `.*`.
+* `exclude-patterns` (optional): one or more newline-separated patterns to exclude matching changed files. If a file matches an exclude pattern, it will be excluded even if it matches an include pattern.
+
+Notes: Patterns are regex-based, as evaluated by Bash’s `=~` operator.
+
+### Outputs
+
+* `all_changed_files`: space-delimited list of all changed files that match the include pattern(s) but not the exclude pattern(s)
+
+### Example
+
+#### Using with individual pattern values
+
+This will match any changed file unless it's in the root-level `.github` folder.
+
+```yaml
+steps:
+  - name:
+    uses: neuralmagic/nm-actions/actions/changed-files@main
+    with:
+      include-patterns: .*
+      exclude-patterns: ^\.github/*
+```
+
+#### Using with multiple pattern values
+
+This will match any file in the root-level `.github` folder, unless it ends in `.md` or `.rst`.
+
+> [!IMPORTANT]
+> When using multi-line values, make sure to use the `|-` syntax as below to eliminate trailing newlines.
+
+```yaml
+steps:
+  - name:
+    uses: neuralmagic/nm-actions/actions/changed-files@main
+    with:
+      include-patterns: |-
+        ^\.github/
+      exclude-patterns: |-
+        \.md$
+        \.rst$
+```

--- a/actions/changed-files/README.md
+++ b/actions/changed-files/README.md
@@ -6,14 +6,14 @@ Used to filter changed files in the current push/pull request.
 
 ### Inputs
 
-* `include-patterns` (required): one or more newline-separated patterns to match changed files. To match any file, use `.*`.
-* `exclude-patterns` (optional): one or more newline-separated patterns to exclude matching changed files. If a file matches an exclude pattern, it will be excluded even if it matches an include pattern.
+- `include-patterns` (required): one or more newline-separated patterns to match changed files. To match any file, use `.*`.
+- `exclude-patterns` (optional): one or more newline-separated patterns to exclude matching changed files. If a file matches an exclude pattern, it will be excluded even if it matches an include pattern.
 
 Notes: Patterns are regex-based, as evaluated by Bash’s `=~` operator.
 
 ### Outputs
 
-* `all_changed_files`: space-delimited list of all changed files that match the include pattern(s) but not the exclude pattern(s)
+- `all_changed_files`: space-delimited list of all changed files that match the include pattern(s) but not the exclude pattern(s)
 
 ### Example
 
@@ -34,8 +34,7 @@ steps:
 
 This will match any file in the root-level `.github` folder, unless it ends in `.md` or `.rst`.
 
-> [!IMPORTANT]
-> When using multi-line values, make sure to use the `|-` syntax as below to eliminate trailing newlines.
+⚠️ **Note:** When using multi-line values, make sure to use the `|-` syntax as below to eliminate trailing newlines.
 
 ```yaml
 steps:

--- a/actions/changed-files/action.yml
+++ b/actions/changed-files/action.yml
@@ -1,4 +1,5 @@
 ---
+name: changed-files
 description: Matches changed files based on include and exclude patterns.
 
 inputs:
@@ -12,7 +13,7 @@ inputs:
 outputs:
   all_changed_files:
     description: return status from change
-    value: ${{ steps.changed.output.all_changed_files }}
+    value: ${{ steps.changed.outputs.all_changed_files }}
 
 runs:
   using: composite

--- a/actions/changed-files/check_changed_files.sh
+++ b/actions/changed-files/check_changed_files.sh
@@ -9,11 +9,11 @@ if [[ -z "${GITHUB_BASE_REF}" ]]; then
 	# this is not a pull request event, just get the previous commit
 	previous_sha=$(git rev-parse --verify 'HEAD^{commit}')
 else
-	previous_sha=${GITHUB_BASE_REF}
+	previous_sha="origin/${GITHUB_BASE_REF}"
 fi
 
 current_branch=$(git branch --show-current)
-CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "origin/${previous_sha}..${current_branch}")
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "${previous_sha}..${current_branch}")
 
 readarray -t INCLUDE_PATTERNS < <(echo "${INCLUDE_PATTERN}")
 readarray -t EXCLUDE_PATTERNS < <(echo "${EXCLUDE_PATTERN}")

--- a/actions/changed-files/check_changed_files.sh
+++ b/actions/changed-files/check_changed_files.sh
@@ -29,7 +29,7 @@ while IFS= read -r file; do
 		fi
 	done
 
-	if [[ ${#EXCLUDE_PATTERNS[@]} -ne 0 ]]; then
+	if [[ ${should_include} -eq 1 ]] && [[ ${#EXCLUDE_PATTERNS[@]} -ne 0 ]]; then
 		for exclude_pattern in "${EXCLUDE_PATTERNS[@]}"; do
 			if [[ "${file}" =~ ${exclude_pattern} ]]; then
 				should_exclude=1


### PR DESCRIPTION
## Summary:

Resolve some issues affecting the 'changed-files' action, as well as support remote branches.

## Details:

- Fix support for remote/external branches when executed in PRs
- Fix referencing output variable in `action.yml`’s outputs block
- Fix reading input arrays
    - Prior, only the first item was being read
- Fix duplication of file matches
    - Prior, any file was included for each include pattern it matched, instead of just once

## Test Plan:

This run tests the changes made in this PR:
https://github.com/vllm-project/llm-compressor/actions/runs/13953464034

Additionally, this test run uses the same inputs but touches various files to ensure the results match what is expected based on include/exclude patterns:
https://github.com/vllm-project/llm-compressor/actions/runs/13954383262/job/39061707849

- Other scenarios currently untested

