### PR TITLE
Fix previous commit retrieval

### DIFF
--- a/actions/changed-files/check_changed_files.sh
+++ b/actions/changed-files/check_changed_files.sh
@@ -7,7 +7,7 @@ set -ex
 
 if [[ -z "${GITHUB_BASE_REF}" ]]; then
 	# this is not a pull request event, just get the previous commit
-	previous_sha=$(git rev-parse --verify 'HEAD^{commit}')
+	previous_sha=$(git rev-parse --verify 'HEAD^')
 else
 	previous_sha="origin/${GITHUB_BASE_REF}"
 fi


### PR DESCRIPTION
## Summary:

Fix the retrieval of the previous commit hash to be compared against.

## Details:

The command currently used to retrieve the previous commit hash is returning the current commit hash, meaning it is comparing the commit against itself and finding no changes.

```shell
$ git log --oneline -4
dc1d4d6 (HEAD -> update-commit-ident, origin/update-commit-ident) Fix previous commit retrieval
57598f5 (tag: v1.14.0, main) Fix 'changed-files' action (#48)
1ec6356 Make your_script.sh executable (#47)
e4c0c0c Add replacement for jt-action github action  (#46)

$ git rev-parse --verify 'HEAD^{commit}'
dc1d4d69a855e9db34e57815a7e598011e10c8d4
# ^ this is the current commit
```

## Test Plan:

The arguments to the CLI command have been tweaked slightly, resulting in the desired behavior:

```shell
$ git rev-parse --verify 'HEAD^'
57598f52d308d41e054b11ce9a52fc32a068ffc5
# ^ this is the previous commit (desired)
```