### PR TITLE
update build action according to build changes using setuptools-scm

### DIFF
--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -53,7 +53,8 @@ runs:
         status=0
         makefile_path=$(find . -type f -name "Makefile")
         cd $(dirname ${makefile_path})
-        make -B build || status=$?
+        #make -B build || status=$?
+        BUILD_TYPE=$BUILD_TYPE python3 -m build . || status=$?
         ls dist/; mkdir build-results
         echo "
         <testsuites>

--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -40,18 +40,15 @@ runs:
         if [[ ! -z "${{ inputs.venv }}" ]]; then
             source ${{ inputs.venv }}/bin/activate
         fi
-        pip install setuptools wheel
+        pip install setuptools-scm build
         name="${{ inputs.name }}"
-        ver_file=$(find . -type f -name "version.py")
+        BUILD_TYPE="dev"
         if ${{ inputs.release }}; then
-          sed -i 's/is_release = False/is_release = True/g' ${ver_file}
-          sed -i 's/build_type = "dev"/build_type = "release"/g' ${ver_file}
+            export BUILD_TYPE="release"
         elif ${{ inputs.dev }}; then
-          sed -i 's/is_dev = False/is_dev = True/g' ${ver_file}
-          sed -i 's/dev_number = None/dev_number = '"$name"'/g' ${ver_file}
+            export BUILD_TYPE="dev"
         else
-            sed -i 's/build_type = "dev"/build_type = "nightly"/g' ${ver_file}
-            sed -i 's/is_release = True/is_release = False/g' ${ver_file}
+            export BUILD_TYPE="nightly"
         fi
         status=0
         makefile_path=$(find . -type f -name "Makefile")

--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -34,7 +34,7 @@ runs:
         pip install virtualenv
         virtualenv venv
         source venv/bin/activate
-        pip setuptools-scm build
+        pip install setuptools-scm build
         BUILD_TYPE="dev"
         if ${{ inputs.release }}; then
             export BUILD_TYPE="release"

--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -11,12 +11,6 @@ inputs:
     description: If the build is a release build
     required: false
     default: false
-  name:
-    description: Name to append to the wheel
-    required: false
-  venv:
-    description: path of virtualenv if using it
-    required: false
 
 outputs:
   whlname:
@@ -37,11 +31,10 @@ runs:
       id: build
       shell: bash
       run: |-
-        if [[ ! -z "${{ inputs.venv }}" ]]; then
-            source ${{ inputs.venv }}/bin/activate
-        fi
-        pip install setuptools-scm build
-        name="${{ inputs.name }}"
+        pip install virtualenv
+        virtualenv venv
+        source venv/bin/activate
+        pip setuptools-scm build
         BUILD_TYPE="dev"
         if ${{ inputs.release }}; then
             export BUILD_TYPE="release"
@@ -50,11 +43,10 @@ runs:
         else
             export BUILD_TYPE="nightly"
         fi
-        status=0
         makefile_path=$(find . -type f -name "Makefile")
         cd $(dirname ${makefile_path})
-        #make -B build || status=$?
-        BUILD_TYPE=$BUILD_TYPE python3 -m build . || status=$?
+        status=0
+        BUILD_TYPE=$BUILD_TYPE python -m build . || status=$?
         ls dist/; mkdir build-results
         echo "
         <testsuites>


### PR DESCRIPTION
## Summary:

Update build action for compressed-tensors and compressed-tensors due to using setuptools-scm.

## Test Plan:

Manually tested the new build commands.
Ran workflow to test the changes automatically:

- nightly build: https://github.com/neuralmagic/compressed-tensors/actions/runs/14316375648/job/40123467680
