### PR TITLE
Update install-* actions

### DIFF
--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -19,24 +19,30 @@ runs:
     - shell: bash
       if: steps.check_os.outputs.os == 'ubuntu'
       run: |-
-        # packages
+        echo "::group::install-automation-components - install curl/git/wget/jq"
         sudo apt update -y
-        sudo apt install -y curl git-all wget jq
-        # install gcc
+        sudo apt install -y curl git-all jq wget
+        echo "::endgroup::"
+
+        echo "::group::install-automation-components - install gcc"
         sudo apt install -y gcc-10 g++-10 lld
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-        # gh cli
-        (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
-        && sudo mkdir -p -m 755 /etc/apt/keyrings \
-        && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-        && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        && sudo apt update \
-        && sudo apt install gh -y
+        echo "::endgroup::"
+
+        echo "::group::install-automation-components - install gh cli tool"
+        sudo mkdir -p -m 755 /etc/apt/keyrings \
+          && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+          && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
+        echo "::endgroup::"
     - shell: bash
       if: steps.check_os.outputs.os == 'ubi-minimal'
       run: |-
         if ! command -v gh &>/dev/null; then
+          echo "::group::install-automation-components - install gh cli tool"
           curl -L https://cli.github.com/packages/rpm/gh-cli.repo | sudo tee /etc/yum.repos.d/gh-cli.repo
           sudo microdnf install -y gh
+          echo "::endgroup::"
         fi

--- a/actions/install-whl/action.yml
+++ b/actions/install-whl/action.yml
@@ -24,15 +24,21 @@ runs:
       run: |
         source "$VENV/bin/activate"
 
+        INSTALL=(pip install)
+
+        if command -v uv; then
+          INSTALL=(uv "${INSTALL[@]}")
+        fi
+
         whl=$(find . -type f -iname "$NAME*.whl")
         if [ -n "$EXTRA" ]; then
           whl="$whl$EXTRA"
         fi
 
-        echo "::group::pip install $whl"
-        pip install "$whl"
+        echo "::group::install-wheel - ${INSTALL[@]} $whl"
+        "${INSTALL[@]}" "$whl"
+        echo "::endgroup::"
 
         version=$(pip freeze | grep "$NAME")
         echo "installed $version"
-        echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
## Summary

This PR updates two of the install-* actions:

- `install-whl` has been updated to support `uv` (if present)
- `install-automation-components` has been updated to organize its output

It also sets/updates some environment variables to take advantage of our pip/uv caches.

## Test Plan

This run shows the `install-whl` update:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/15327972527
- in the "prepare environment" step, the `install-whl` action uses `uv` because it was detected as available:
```
[...]
install-wheel - uv pip install ./15327972527/llmcompressor-0.5.2a20250529-py3-none-any.whl[dev]
[...]
installed llmcompressor @ file:///home/runner/_work/llm-compressor-testing/llm-compressor-testing/15327972527/llmcompressor-0.5.2a20250529-py3-none-any.whl
[...]
```

Additionally, this run shows the changes working without having `uv` installed:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/15329129352
- in the "prepare environment" step, the `install-whl` action uses “plain” `pip` because `uv`was not detected as available:

```
[...]
install-wheel - pip install ./15329129352/llmcompressor-0.5.2a20250529-py3-none-any.whl[dev]
[...]
installed llmcompressor @ file:///home/runner/_work/llm-compressor-testing/llm-compressor-testing/15329129352/llmcompressor-0.5.2a20250529-py3-none-any.whl#sha256=7fe5907376c54d3ba3c382de38f1eca8e9c1b5b593b3d6f77d240f8c7cd816b2
[...]
```

This contrived run shows the `install-automation-components` update (that step only):
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/15328521799
- in the single step, the output for different install portions is now captured in separate groups