### PR TITLE
look for droute_send_template.json in $GITHUB_ACTION_PATH

### DIFF
--- a/actions/reportportal_submit_execution_results/action.yml
+++ b/actions/reportportal_submit_execution_results/action.yml
@@ -71,7 +71,7 @@ runs:
 
         # generate report metadata file
         TEMPLATE="${GITHUB_ACTION_PATH}/droute_send_template.json"
-        if [ -z "$TEMPLATE" ]; then
+        if [ -f $TEMPLATE ]; then
           echo "droute_send_template.json not found in $GITHUB_ACTION_PATH"
           exit 1
         fi

--- a/actions/reportportal_submit_execution_results/action.yml
+++ b/actions/reportportal_submit_execution_results/action.yml
@@ -71,7 +71,7 @@ runs:
 
         # generate report metadata file
         TEMPLATE="${GITHUB_ACTION_PATH}/droute_send_template.json"
-        if [ -f $TEMPLATE ]; then
+        if [ ! -f $TEMPLATE ]; then
           echo "droute_send_template.json not found in $GITHUB_ACTION_PATH"
           exit 1
         fi

--- a/actions/reportportal_submit_execution_results/action.yml
+++ b/actions/reportportal_submit_execution_results/action.yml
@@ -70,7 +70,7 @@ runs:
         ls $TEST_RESULTS
 
         # generate report metadata file
-        TEMPLATE=`find ~ -type f -name 'droute_send_template.json'`
+        TEMPLATE=`find $GITHUB_ACTION_PATH -type f -name 'droute_send_template.json'`
         echo "Generating datarouter.json based on template $TEMPLATE"
         jq --raw-output \
            --slurpfile metadata ${{ inputs.metadata_filepath }} \

--- a/actions/reportportal_submit_execution_results/action.yml
+++ b/actions/reportportal_submit_execution_results/action.yml
@@ -70,7 +70,7 @@ runs:
         ls $TEST_RESULTS
 
         # generate report metadata file
-        TEMPLATE=`find $GITHUB_ACTION_PATH -type f -name 'droute_send_template.json'`
+        TEMPLATE="${GITHUB_ACTION_PATH}/droute_send_template.json"
         if [ -z "$TEMPLATE" ]; then
           echo "droute_send_template.json not found in $GITHUB_ACTION_PATH"
           exit 1

--- a/actions/reportportal_submit_execution_results/action.yml
+++ b/actions/reportportal_submit_execution_results/action.yml
@@ -71,7 +71,7 @@ runs:
 
         # generate report metadata file
         TEMPLATE="${GITHUB_ACTION_PATH}/droute_send_template.json"
-        if [ ! -f $TEMPLATE ]; then
+        if [[ ! -f "$TEMPLATE" ]]; then
           echo "droute_send_template.json not found in $GITHUB_ACTION_PATH"
           exit 1
         fi

--- a/actions/reportportal_submit_execution_results/action.yml
+++ b/actions/reportportal_submit_execution_results/action.yml
@@ -71,6 +71,11 @@ runs:
 
         # generate report metadata file
         TEMPLATE=`find $GITHUB_ACTION_PATH -type f -name 'droute_send_template.json'`
+        if [ -z "$TEMPLATE" ]; then
+          echo "droute_send_template.json not found in $GITHUB_ACTION_PATH"
+          exit 1
+        fi
+
         echo "Generating datarouter.json based on template $TEMPLATE"
         jq --raw-output \
            --slurpfile metadata ${{ inputs.metadata_filepath }} \


### PR DESCRIPTION
## Summary:
We need to be more specific about where to find the droute_sent_template.json file.

## Details:
the compressed-tensors nightly job is failing.  https://github.com/neuralmagic/compressed-tensors/actions/runs/15695266055/job/44251855599
the error is:
```
Submitting test run to ReportPortal...
Invalid --metadata: 'invalid character '{' after top-level value'
Error: Process completed with exit code 2.
```

It appears that inside the `neuralmagic/nm-actions/actions/reportportal_submit_execution_results@v1.15.0` action, the command:
```
TEMPLATE=`find ~ -type f -name 'droute_send_template.json'`
```
Is returning two different files with the same name:
`/home/runner/actions-runner/_work/nm-cicd/nm-cicd/.github/actions/submit-to-report-portal/droute_send_template.json` and
`/home/runner/actions-runner/_work/_actions/neuralmagic/nm-actions/v1.15.0/actions/reportportal_submit_execution_results/droute_send_template.json`

Then the `jq` command in the action is run for both files, duplicating the content of the generated datarouter.json file.  This explains how the content of the json is bad.

The extra file is /home/runner/actions-runner/_work/nm-cicd/nm-cicd/.github/actions/submit-to-report-portal/droute_send_template.json, but I don’t get how/when nm-cicd was installed, or why the installed version even has that action.

The workaround is to adjust the `find` command to look where the current job's actions were downloaded.  That is available as the `$GITHUB_ACTION_PATH` env var.

## Test Plan:

I've verified that the syntax of using an env var with the `find` command works as expected.  The thing I haven't done is confirm that the `$GITHUB_ACTION_PATH` resolves correctly, but the documentation [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables) indicates that it's the path I expect.

## Related Issues:
N/A