### PR TITLE
allow getting empty results to check vllm latest versions on pypi

### DIFF
--- a/actions/get-pypi-latest-versions/action.yml
+++ b/actions/get-pypi-latest-versions/action.yml
@@ -36,10 +36,6 @@ runs:
         echo "get-pypi-latest-versions - cleaning up virtual environment"
         rm -r "$VENV_NAME"
 
-        if [ -z "$versions" ]; then
-          exit 1
-        fi
-
         echo "versions=$versions" >> $GITHUB_OUTPUT
       env:
         PACKAGE_NAME: ${{ inputs.package_name }}


### PR DESCRIPTION
## Summary:

Minor update to allow empty results returned for get-pypi-latest-versions.

## Details:

Allow empty results returned and not error out. The step calling this action can decide to error out or not if empty results are returned.

## Test Plan:

Run all tests.

