### PR TITLE
minor fix for uv env

### DIFF
--- a/actions/install-whl/action.yml
+++ b/actions/install-whl/action.yml
@@ -25,9 +25,11 @@ runs:
         source "$VENV/bin/activate"
 
         INSTALL=(pip install)
+        FREEZE=(pip freeze)
 
         if command -v uv; then
           INSTALL=(uv "${INSTALL[@]}")
+          FREEZE=(uv "${FREEZE[@]}")
         fi
 
         whl=$(find . -type f -iname "$NAME*.whl")
@@ -39,6 +41,6 @@ runs:
         "${INSTALL[@]}" "$whl"
         echo "::endgroup::"
 
-        version=$(pip freeze | grep "$NAME")
+        version=$("${FREEZE[@]}" | grep "$NAME")
         echo "installed $version"
       shell: bash


### PR DESCRIPTION
## Summary:

Fix a minor issue that when using uv venv "pip freeze" command may fail.

## Details:

Use "uv pip freeze" when uv venv is used

## Test Plan:

- run all tests
