### PR TITLE
[build-ml-whl] Improve safety and logging

### DIFF
--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -48,7 +48,7 @@ runs:
         fi
         echo "BUILD_TYPE=${BUILD_TYPE}"
 
-        makefile_path=$(find . -maxdepth 2 -type f -name "Makefile" | head -1)
+        makefile_path=$(find . -maxdepth 2 -type f -name "Makefile")
         echo "makefile_path=${makefile_path}"
         makefile_dir=$(dirname "${makefile_path}")
         echo "makefile_dir=${makefile_dir}"

--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -48,7 +48,7 @@ runs:
         fi
         echo "BUILD_TYPE=${BUILD_TYPE}"
 
-        makefile_path=$(find . -type f -name "Makefile")
+        makefile_path=$(find . -maxdepth 2 -type f -name "Makefile" | head -1)
         echo "makefile_path=${makefile_path}"
         makefile_dir=$(dirname "${makefile_path}")
         echo "makefile_dir=${makefile_dir}"

--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -23,31 +23,36 @@ outputs:
     description: status of wheel build
     value: ${{ steps.build.outputs.status }}
 
-# can we just pass in build args instead of updating the variables in version.py?
 runs:
   using: composite
   steps:
     - name: build
       id: build
-      shell: bash
       run: |-
+        echo "::group::Installing virtualenv and creating a venv"
         pip install virtualenv
         virtualenv venv
-        source venv/bin/activate
-        pip install setuptools-scm==8.2.0
+        echo "::endgroup::"
 
-        BUILD_TYPE="dev"
+        source venv/bin/activate
+
+        echo "::group::Installing setuptools-scm"
+        pip install setuptools-scm==8.2.0
+        echo "::endgroup::"
+
+        BUILD_TYPE="nightly"
         if ${{ inputs.release }}; then
             export BUILD_TYPE="release"
         elif ${{ inputs.dev }}; then
             export BUILD_TYPE="dev"
-        else
-            export BUILD_TYPE="nightly"
         fi
         echo "BUILD_TYPE=${BUILD_TYPE}"
 
         makefile_path=$(find . -type f -name "Makefile")
-        cd $(dirname ${makefile_path})
+        echo "makefile_path=${makefile_path}"
+        makefile_dir=$(dirname "${makefile_path}")
+        echo "makefile_dir=${makefile_dir}"
+        cd "${makefile_dir}"
 
         status=0
         make build || status=$?
@@ -55,21 +60,22 @@ runs:
         TARGZ_NAME=$(find dist -name '*.tar.gz' -exec basename {} \;)
 
         # check if created wheel match build type
-        if [[ $BUILD_TYPE = "dev" ]] && [[ ! "$WHL_NAME" =~ \.dev ]]; then
-            echo "ERROR: $WHL_NAME not dev build"
+        if [[ ${BUILD_TYPE} = "dev" ]] && [[ ! "${WHL_NAME}" =~ \.dev ]]; then
+            echo "ERROR: ${WHL_NAME} does not match dev build naming pattern"
             status=1
         fi
-        if [[ $BUILD_TYPE = "release" ]] && ([[ "$WHL_NAME" =~ \.dev ]] || [[ "$WHL_NAME" =~ a[0-9]{8}- ]]); then
-            echo "ERROR: $WHL_NAME not release build"
+        if [[ ${BUILD_TYPE} = "release" ]] && ([[ "${WHL_NAME}" =~ \.dev ]] || [[ "${WHL_NAME}" =~ a[0-9]{8}- ]]); then
+            echo "ERROR: ${WHL_NAME} does not match release build naming pattern"
             status=1
         fi
-        if [[ $BUILD_TYPE = "nightly" ]] && [[ ! "$WHL_NAME" =~ a[0-9]{8}- ]]; then
-            echo "ERROR: $WHL_NAME not nightly build"
+        if [[ ${BUILD_TYPE} = "nightly" ]] && [[ ! "${WHL_NAME}" =~ a[0-9]{8}- ]]; then
+            echo "ERROR: ${WHL_NAME} does not match nightly build naming pattern"
             status=1
         fi
 
         echo "=========== Build Status ==========="
-        echo "whlname=$WHL_NAME" | tee -a "$GITHUB_OUTPUT"
-        echo "tarname=$TARGZ_NAME" | tee -a "$GITHUB_OUTPUT"
+        echo "whlname=${WHL_NAME}" | tee -a "$GITHUB_OUTPUT"
+        echo "tarname=${TARGZ_NAME}" | tee -a "$GITHUB_OUTPUT"
         echo "status=${status}" | tee -a "$GITHUB_OUTPUT"
         exit ${status}
+      shell: bash

--- a/actions/build-ml-whl/action.yaml
+++ b/actions/build-ml-whl/action.yaml
@@ -40,11 +40,11 @@ runs:
         pip install setuptools-scm==8.2.0
         echo "::endgroup::"
 
-        BUILD_TYPE="nightly"
+        export BUILD_TYPE="nightly"
         if ${{ inputs.release }}; then
-            export BUILD_TYPE="release"
+            BUILD_TYPE="release"
         elif ${{ inputs.dev }}; then
-            export BUILD_TYPE="dev"
+            BUILD_TYPE="dev"
         fi
         echo "BUILD_TYPE=${BUILD_TYPE}"
 


### PR DESCRIPTION
## Summary:

Improve general scripting safety and logging of `build-ml-whl`.

## Details:

Recently, the build job started failing: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/16765257143/job/47524176286

```
/home/runner/_work/_temp/50ab11ad-06e5-463a-aca3-98222a2695e3.sh: line 17: cd: too many arguments
```

With the logging added in this branch’s initial commit, it was learned that this was due to the project adding another Makefile in a subdirectory, thus confusing the results which only ever expected to find a single Makefile:

```
makefile_path=./llm-compressor/Makefile
./llm-compressor/docs/Makefile
makefile_dir=./llm-compressor/Makefile
./llm-compressor/docs
/home/runner/_work/_temp/61bfa8a4-a12b-4e4d-8f2d-95bfd16d2ea0.sh: line 24: cd: $'./llm-compressor/Makefile\n./llm-compressor/docs': No such file or directory
```

The newly added `-maxdepth 2` flag for this command limits the depths that it will search for the Makefile in a way that is compatible with our existing projects/usages and reduces the chances this particular issue will occur again. A further future-proofing would be to replace the `find` usage with an input specifying the dir to run the `make` command, or at least have it optional so the `find` command is a fallback if not specified.

## Test Plan:

- [x] https://github.com/neuralmagic/llm-compressor-testing/actions/runs/16782152450
