### PR TITLE
Update create-virtualenv action with uv support

### DIFF
--- a/actions/create-virtualenv/action.yml
+++ b/actions/create-virtualenv/action.yml
@@ -25,8 +25,10 @@ runs:
         VENV_NAME: ${{ inputs.venv }}
       run: |
         if [[ ${USE_UV} == 'true' ]] && command -v uv; then
+          echo "Creating venv named '${VENV_NAME}' with uv"
           uv venv "${VENV_NAME}"
         else
+          echo "Creating venv named '${VENV_NAME}' with virtualenv"
           python -m pip install virtualenv
           python -m virtualenv "${VENV_NAME}"
         fi

--- a/actions/create-virtualenv/action.yml
+++ b/actions/create-virtualenv/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         if command -v uv; then
           echo "Creating venv named '${VENV_NAME}' with uv"
-          uv venv "${VENV_NAME}"
+          uv venv --seed "${VENV_NAME}"
         else
           echo "Creating venv named '${VENV_NAME}' with virtualenv"
           python -m pip install virtualenv

--- a/actions/create-virtualenv/action.yml
+++ b/actions/create-virtualenv/action.yml
@@ -6,10 +6,6 @@ inputs:
   venv:
     description: name of virtualenv
     required: true
-  use_uv:
-    description: if 'true', use uv if available (falls back to virtualenv if not) (default='true')
-    required: false
-    default: 'true'
 
 outputs:
   penv:
@@ -21,10 +17,9 @@ runs:
   steps:
     - id: env
       env:
-        USE_UV: ${{ inputs.use_uv }}
         VENV_NAME: ${{ inputs.venv }}
       run: |
-        if [[ ${USE_UV} == 'true' ]] && command -v uv; then
+        if command -v uv; then
           echo "Creating venv named '${VENV_NAME}' with uv"
           uv venv "${VENV_NAME}"
         else

--- a/actions/create-virtualenv/action.yml
+++ b/actions/create-virtualenv/action.yml
@@ -1,11 +1,15 @@
 ---
 name: create virtualenv
-description: create virtualenv using input name
+description: create virtualenv using input name in the default working directory
 
 inputs:
   venv:
     description: name of virtualenv
     required: true
+  use_uv:
+    description: if 'true', use uv if available (falls back to virtualenv if not) (default='true')
+    required: false
+    default: 'true'
 
 outputs:
   penv:
@@ -16,10 +20,19 @@ runs:
   using: composite
   steps:
     - id: env
+      env:
+        USE_UV: ${{ inputs.use_uv }}
+        VENV_NAME: ${{ inputs.venv }}
       run: |
-        # install virtualenv
-        python -m pip install virtualenv
-        python -m virtualenv ${{ inputs.venv }}
-        pwd; ls -al
-        echo "penv=$(pwd)/${{ inputs.venv }}" >> "$GITHUB_OUTPUT" 
+        if [[ ${USE_UV} == 'true' ]] && command -v uv; then
+          uv venv "${VENV_NAME}"
+        else
+          python -m pip install virtualenv
+          python -m virtualenv "${VENV_NAME}"
+        fi
+
+        echo "::group::$(pwd) contents:"
+        ls -Al
+        echo "::endgroup::"
+        echo "penv=$(pwd)/${VENV_NAME}" >> "${GITHUB_OUTPUT}"
       shell: bash


### PR DESCRIPTION
## Summary:

Update the `create-virtualenv` action to use `uv` by default (if available).

## Details:

~This can be disabled via a new optional input, and~ it will always gracefully revert to the default `virtualenv` approach if `uv` is not available. Console output is improved and includes indication of which method was used to create the virtual environment.

## Test Plan:

~https://github.com/neuralmagic/nm-actions/actions/runs/18316851985~
https://github.com/neuralmagic/nm-actions/actions/runs/18318373377