### PR TITLE
Add RHEL (dnf) support to install-automation-components

### DIFF
--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -51,9 +51,17 @@ runs:
     - shell: bash
       if: steps.check_os.outputs.os == 'rhel'
       run: |-
-        echo "::group::install-automation-components - install curl/git/wget/jq/gcc"
-        sudo dnf install -y curl git jq wget gcc gcc-c++ lld
-        echo "::endgroup::"
+        missing=()
+        for cmd in curl git jq wget gcc g++ lld; do
+          command -v "$cmd" &>/dev/null || missing+=("$cmd")
+        done
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::group::install-automation-components - install ${missing[*]}"
+          sudo dnf install -y "${missing[@]}"
+          echo "::endgroup::"
+        else
+          echo "All required packages already installed, skipping dnf"
+        fi
 
         if ! command -v gh &>/dev/null; then
           echo "::group::install-automation-components - install gh cli tool"

--- a/actions/install-automation-components/action.yml
+++ b/actions/install-automation-components/action.yml
@@ -12,6 +12,8 @@ runs:
           echo "os=ubuntu" | tee -a "$GITHUB_OUTPUT"
         elif command -v microdnf &>/dev/null; then
           echo "os=ubi-minimal" | tee -a "$GITHUB_OUTPUT"
+        elif command -v dnf &>/dev/null; then
+          echo "os=rhel" | tee -a "$GITHUB_OUTPUT"
         else
           echo "::error::unknown OS"
           exit 1
@@ -44,5 +46,18 @@ runs:
           echo "::group::install-automation-components - install gh cli tool"
           curl -L https://cli.github.com/packages/rpm/gh-cli.repo | sudo tee /etc/yum.repos.d/gh-cli.repo
           sudo microdnf install -y gh
+          echo "::endgroup::"
+        fi
+    - shell: bash
+      if: steps.check_os.outputs.os == 'rhel'
+      run: |-
+        echo "::group::install-automation-components - install curl/git/wget/jq/gcc"
+        sudo dnf install -y curl git jq wget gcc gcc-c++ lld
+        echo "::endgroup::"
+
+        if ! command -v gh &>/dev/null; then
+          echo "::group::install-automation-components - install gh cli tool"
+          curl -L https://cli.github.com/packages/rpm/gh-cli.repo | sudo tee /etc/yum.repos.d/gh-cli.repo
+          sudo dnf install -y gh
           echo "::endgroup::"
         fi


### PR DESCRIPTION
## Summary
- MI355X bare-metal runners use RHEL with `dnf`, not Ubuntu (`apt-get`) or UBI minimal (`microdnf`)
- The OS detection in `install-automation-components` only handled those two, causing all TEST and LM-EVAL jobs on MI355X to fail with `"unknown OS"`
- Adds `dnf` detection and full package installation for bare-metal RHEL (curl, git, jq, wget, gcc, gcc-c++, lld, gh)

## Context
This unblocks ROCm 7 MI355X validation (INFERENG-5254). The existing `rhel-updates` branch had a partial fix (gh CLI only) but didn't install the full package set.

## Test plan
- [x] Verified MI355X runners have `dnf` available
- [ ] Re-run accept-sync TEST/LM-EVAL jobs on MI355X with `v1.25.0-beta` tag pointing to this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)